### PR TITLE
changed tile merging to support union based merging

### DIFF
--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1272,7 +1272,7 @@ class SpotTable:
         include_inds = self.cell_indices(include_cells)
         return include_inds
 
-    def merge_cells(self, other, padding=5):
+    def merge_cells(self, other, padding=5, union_threshold=0.5):
         """Merge cell IDs from SpotTable *other* into self.
 
         Returns a structure describing merge conflicts.
@@ -1323,7 +1323,7 @@ class SpotTable:
                 if overlap_cell == cell_id: continue
             
                 overlap_size = np.count_nonzero(np.in1d(overlapped_cell_inds[overlap_cell], old_inds))
-                if overlap_size / min(original_cell_size, size) > 0.5: # if the overlap transcripts represents >50% of the transcripts of the smaller cell i.e. the smaller cell is mostly 'absorbed'
+                if overlap_size / min(original_cell_size, size) > union_threshold: # if the overlap transcripts represents >threshold of the transcripts of the smaller cell i.e. the smaller cell is mostly 'absorbed'
                     to_combine.append(overlap_cell)
                 overlaps[overlap_cell] = overlap_size
                 overlap_pct[overlap_cell] = overlap_size / min(original_cell_size, size)


### PR DESCRIPTION
Addressing Issue #14:

Functions Changed:
 - `sis.spot_table.SpotTable.merge_cells()`
     - Now merges two cells together if the size of their overlap (by transcript count) is > 50% of the size of the smaller of the two cells (by transcript count)
          - i.e. if the smaller cell has been mostly 'absorbed', it is merged into the larger cell
     - A couple more statistics have been added to the conflict tracking
          - `merged_cells`
          - `merged_cell_overlap_sizes`
          - `merged_cell_overlap_ratios`
          - `new_indices`
     - `size_ratio` has been removed from the conflict tracking

Results:
Highlighting cells which did not pass QC statistics (< 40 transcripts or < 8 genes):
![low_quality_cells_comparison_full_pipeline](https://github.com/AllenInstitute/spots-in-space/assets/49694583/940b9ab3-0535-4e63-8708-e74d278719bf)

All merged cells shown in detail:
`/allen/programs/celltypes/workgroups/rnaseqanalysis/mFISH/jacobquon/sawghack/fixing_merging/all_merge_conflicts_full_pipeline.png`