### PR TITLE
Create SegmentedSpotTable from SpotTable

### DIFF
--- a/sis/segmentation.py
+++ b/sis/segmentation.py
@@ -1158,11 +1158,16 @@ class SegmentationPipeline:
 
         print('Merging tiles...')
         # Merging updates the spot table cell_ids in place
+        truncated_meta = {
+                'seg_method': str(self.seg_method),
+                'seg_opts': self.seg_opts,
+                'polygon_opts': self.polygon_opts
+                }
+
         self.seg_spot_table = SegmentedSpotTable.from_spot_table(
                 spot_table=self.raw_spot_table, 
                 cell_ids=np.empty(len(self.raw_spot_table), dtype=int),
-                seg_method=str(self.seg_method),
-                seg_opts=self.seg_opts
+                seg_metadata=truncated_meta,
                 )
         self.seg_spot_table.cell_ids[:] = -1
 


### PR DESCRIPTION
Addresses https://github.com/AllenInstitute/spots-in-space/issues/13 and also https://github.com/AllenInstitute/spots-in-space/issues/15 to some extent. Edit: and also https://github.com/AllenInstitute/spatial-analysis-wg/issues/57

-	Created `SegmentedSpotTable`, a subclass of `SpotTable`. All methods related to cells have been moved from `SpotTable` to `SegmentedSpotTable`. `SpotTable` is created without cell_ids, whereas `SegmentedSpotTable`s require cell_ids. `SegmentedSpotTable` can optionally include attributes describing segmentation-related metadata.
-	Updated alternate constructors to work with inheritance. Calling methods like `load_merscope` from `SpotTable` loads a raw spot table with no cell_ids, which is recommended for resegmentation. To include the original segmentation, call `load_merscope` from `SegmentedSpotTable`. The latter is currently not supported for StereoSeq due to changes in file formats.
-	`SegmentedSpotTable.save_npz` now supports additional fields and `SegmentedSpotTable.load_npz` can be called with `allow_pickle=True` to handle objects.
-	`SegmentationResult` and `SegmentationPipeline` were updated to use `SegmentedSpotTable`. `SegmentationPipeline` now saves the output `SegmentedSpotTable` as an npz file. It also passes along segmentation metadata so it is saved within the final output `SegmentedSpotTable` and cell by gene table.
-	`run_cell_polygon_calculation` now loads a `SegmentedSpotTable` instead of a regular one, and therefore no longer needs `cell_id_file` as an argument.

Disclaimer: I haven't tested everything related to this change, but I was able to successfully run a MerscopeSegmentationPipeline on a subregion. Also, I looked at `spot_table.py` and `segmentation.py`, but I still need to check things like `utils.py` to see if anything needs to be updated there.