### PR TITLE
Resume seg bugfix

### DIFF
--- a/sis/segmentation.py
+++ b/sis/segmentation.py
@@ -1464,7 +1464,7 @@ class SegmentationPipeline:
             failure_types: dict
                 A dictionary with keys as types of failues and bools representing if that failure occured in the inputted SlurmJobArray
         """
-        job_state_dict = self.seg_jobs.state()
+        job_state_dict = jobs.state()
         failure_types= {"OUT_OF_MEMORY": False, "TIMEOUT": False, "CANCELLED": False}
         failed_jobs_indices = []
         for job_index, job_state in enumerate(job_state_dict.values()):


### PR DESCRIPTION
Fixed a bug where if jobs failed after rerun, the job indices that needed to be rerun would be incorrectly saved and `rerun_failed_jobs()` would attempt to rerun the wrong jobs repeatedly until the `max_loops` was reached.
![image](https://github.com/AllenInstitute/spots-in-space/assets/49694583/8e52e4c4-23ac-449f-81b4-31e57a10c849)
This was caused by job indices being pulled from `SlurmJob.job_id`, instead they should have been pulled from the index in the `SlurmJobArray.jobs` list as this is what was being modified.