### PR TITLE
updating PTS query

### DIFF
--- a/sis/spatial_dataset.py
+++ b/sis/spatial_dataset.py
@@ -289,15 +289,7 @@ class SpatialDataset:
 class MERSCOPESection(SpatialDataset):
 
 
-    def __init__(self, barcode, configfile=None, overwrite=False):
-        
-        
-        self.pts_qc_filt = pts_schema.MetadataFilterInput(type=pts_schema.DataTypeFilterInput(name=pts_schema.StringOperationFilterInput(eq="QCMetadata")))
-        self.pts_request_filt = pts_schema.MetadataFilterInput(type=pts_schema.DataTypeFilterInput(name=pts_schema.StringOperationFilterInput(eq="MerscopeImagingRequestMetadata")))
-
-        
-        
-        
+    def __init__(self, barcode, configfile=None, overwrite=False):     
         config = load_config(configfile)
         save_path = Path(config['merscope_save_path']).joinpath(str(barcode))
         if os.path.exists(save_path.joinpath('spatial_dataset')) and not overwrite:
@@ -346,13 +338,22 @@ class MERSCOPESection(SpatialDataset):
         self.plane_of_section =  bers_spec.external_data.plane_of_section.name
         
         spec_pts = pts.get_processes_by_biological_entities(bers_spec.id)
-        assert spec_pts.total_count == 1 and 'MerscopeCoverslipProcessing' in spec_pts.nodes[0].name, "not a MERSCOPE process"
-        merscope_expt = spec_pts.nodes[0]
+        assert spec_pts.total_count > 0, "no processes found for this specimen"
+        merscope_expt = None
+        for process in spec_pts.nodes:
+            if 'MerscopeCoverslipProcessing' in process.name:
+                merscope_expt = process
+                continue
+
+        assert merscope_expt is not None, "not a MERSCOPE process"
+
+        pts_qc_filt = pts_schema.MetadataFilterInput(type=pts_schema.DataTypeFilterInput(name=pts_schema.StringOperationFilterInput(eq="QCMetadata")))
+        pts_request_filt = pts_schema.MetadataFilterInput(type=pts_schema.DataTypeFilterInput(name=pts_schema.StringOperationFilterInput(eq="MerscopeImagingRequestMetadata")))
         
         self.qc_state = pts.get_process_metadata(process_id = merscope_expt.id, 
-                                                 metadata_filter_input = self.pts_qc_filt)[0].data['QC_State']
+                                                 metadata_filter_input = pts_qc_filt)[0].data['QC_State']
         self.gene_panel = pts.get_process_metadata(process_id = merscope_expt.id, 
-                                                   metadata_filter_input = self.pts_request_filt)[0].data['GenePanel']
+                                                   metadata_filter_input = pts_request_filt)[0].data['GenePanel']
         self.merscope_expt_pts_id = merscope_expt.id
         
 #         self.section_thickness # not sure where this comes from?


### PR DESCRIPTION
Specimens can have multiple PTS processes so needed to update query in SpatialDataset to comb through and find the write one for MERSCOPE

Also moving the PTS filters to instance attributes from class attributes seems to have prevented pickling of the SpatailDataset object. Since these are only used in one place removed them as attributes altogether and just call where needed