### PR TITLE
Bug Fix: Cell-by-gene was not working for SSTs w/o polygons or w/ 2d polygons

### DIFF
--- a/sis/segmentation.py
+++ b/sis/segmentation.py
@@ -881,7 +881,7 @@ class SegmentationPipeline:
         else:
             # geojson objects must be converted to strings before saving
             for k, v in cell_by_gene.uns.items():
-                if isinstance(v, geojson.feature.FeatureCollection):
+                if isinstance(v, geojson.feature.FeatureCollection) or isinstance(v, geojson.geometry.GeometryCollection):
                     cell_by_gene.uns[k] = geojson.dumps(v)
             cell_by_gene.write(self.cbg_path)
 

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1424,7 +1424,9 @@ class SegmentedSpotTable:
         """
         Create a geojson feature/geometry collection from the cell polygons
         """
-        if dict in set(type(k) for k in self.cell_polygons.values()): # if cell polygons are separated by z-plane use feature collection which stores z-plane info
+        if self.cell_polygons is None:
+            return None
+        elif dict in set(type(k) for k in self.cell_polygons.values()): # if cell polygons are separated by z-plane use feature collection which stores z-plane info
             all_polygons = []
             for cid in self.cell_polygons:
                 if self.cell_polygons[cid]:


### PR DESCRIPTION
`sis.spot_table.SegmentedSpotTable.cell_by_gene_anndata()` was bugging out when the spot table had no polygons. 
The `self.get_geojson_collection(use_production_ids=True)` call when setting `adata.uns` was giving the following error: `AttributeError: 'NoneType' object has no attribute 'values'`
Now, `get_geojson_collection()` first checks if `cell_polygons() is None` and returns `None` immediately if so. This way it avoids the error arising from the subsequent if-else statement.

`sis.segmentation.SegmentationPipeline.save_cbg()` would bug out if the SpotTable's polygons were flat because they would be stored as a `geojson.geometry.GeometryCollection` in the anndata object. The `geojson.dumps()` call only checked for `geojson.feature.FeatureCollection` and thus would not properly dump the polygons and would raise an error when trying to write the anndata object.