### PR TITLE
fixed load_polygons bug with SegmentationPipeline and 2d polygons

### DIFF
--- a/sis/segmentation.py
+++ b/sis/segmentation.py
@@ -1330,12 +1330,13 @@ class SegmentationPipeline:
         skipped = []
         for i, area_spec in enumerate(tqdm(run_spec.values())):
             result_file = area_spec[2]['result_file']
+            cell_subset_file = area_spec[2]['cell_subset_file']
             if not os.path.exists(result_file):
                 print(f"Skipping tile {i} : no result file generated")
                 skipped.append(i)
                 continue
 
-            self.seg_spot_table.load_cell_polygons(result_file, reset_cache=False, disable_tqdm=True) # The reset_cache=False is important to allow reading in the various cell subsets without overwriting
+            self.seg_spot_table.load_cell_polygons(result_file, cell_ids=cell_subset_file, reset_cache=False, disable_tqdm=True) # The reset_cache=False is important to allow reading in the various cell subsets without overwriting
 
         if len(run_spec) == len(skipped):
             raise RuntimeError('All tiles were skipped, check error logs.')

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1540,9 +1540,21 @@ class SegmentedSpotTable:
                 pickle.dump(self.cell_polygons, f)
 
     
-    def load_cell_polygons(self, load_path: Path|str, reset_cache=True, disable_tqdm=False):
+    def load_cell_polygons(self, load_path: Path|str, cell_ids: Path|str|list|np.ndarray|None=None, reset_cache=True, disable_tqdm=False):
         """
         load cell polygons from a geojson feature collection file
+
+        Parameters
+        ----------
+        load_path : Path|str
+            Path to the file containing the cell polygons. Can be either '.geojson' or '.pkl'
+        cell_ids [OPTIONAL]: Path|str|list|np.ndarray|None
+            Path/str to .npy file containing cell ids corresponding to cell polygons for GeometryCollection
+            list/np.ndarray containing cell ids corresponding to cell polygons for GeometryCollection
+            Used to assign polygons to cell ids for GeometryCollection b/c it does not store IDs. 
+            This is important if you want to load in a bunch of 2D polygons files w/o reseting the cache as we have no way to determine proper ID
+            If not provided and using GeometryCollection, it is assumed the cell polygons are in order of the sorted cell ids
+            GeometryCollections may contain None for uncalculated polygons or may exclude them entirely
         """
         # Handle input errors
         if isinstance(load_path, Path) or isinstance(load_path, str):
@@ -1551,22 +1563,22 @@ class SegmentedSpotTable:
                 raise ValueError('Invalid path extension. Can only load .pkl or .geojson')
         else:
             raise ValueError('Invalid path type. Please use pathlib.Path or str')
-    
+
         if reset_cache or self.cell_polygons is None:
             self.cell_polygons = {}
-    
+
         if extension == '.geojson': 
             import json
             from shapely.geometry.polygon import Polygon
-    
+
             with open(load_path, "r") as f:
                 polygon_json = json.load(f)
-    
+
             unique_cells = np.unique(self.cell_ids)
             unique_cells = np.delete(unique_cells, np.where((unique_cells == 0) | (unique_cells == -1)))
             cell_id_type = type(unique_cells[0])
             z_plane_type = None if self.pos.shape[1] < 3 else type(self.pos[0, 2])
-    
+
             if polygon_json['type'] == 'FeatureCollection':
                 for feature in tqdm(polygon_json['features'], disable=disable_tqdm):
                     cid = cell_id_type(feature['id'])
@@ -1579,19 +1591,33 @@ class SegmentedSpotTable:
                         elif not feature['geometry']:
                             self.cell_polygons[cid] = feature['geometry']
             elif polygon_json['type'] == 'GeometryCollection':
-                if len(unique_cells) < len(polygon_json['geometries']):
-                    raise ValueError("Number of cells in input file exceeds SpotTable")
+                from pathlib import PurePath
+                if cell_ids and (isinstance(cell_ids, PurePath) or isinstance(cell_ids, str)):
+                    cell_ids = list(np.load(cell_ids))
+                elif cell_ids and isinstance(cell_ids, np.ndarray):
+                    cell_ids = list(cell_ids)
 
-                # This method ensure compatibility with both JSONs which store None and those which dont
-                valid_cells = [cid for cid in unique_cells if len(self.cell_indices(cid)) > 3]
-                invalid_cells = [cid for cid in unique_cells if len(self.cell_indices(cid)) <= 3]
-                
-                for geometry in tqdm(polygon_json['geometries'], disable=disable_tqdm):
-                    if geometry and geometry['type'] == 'Polygon':
-                        polygon = Polygon(geometry['coordinates'][0])
-                        self.cell_polygons[valid_cells.pop(0)] = polygon
-                    elif not geometry:
-                        self.cell_polygons[invalid_cells.pop(0)] = geometry
+                if cell_ids:
+                    for geometry in tqdm(polygon_json['geometries'], disable=disable_tqdm):
+                        if geometry and geometry['type'] == 'Polygon':
+                            polygon = Polygon(geometry['coordinates'][0])
+                            self.cell_polygons[cell_ids.pop(0)] = polygon
+                        elif not geometry:
+                            self.cell_polygons[cell_ids.pop(0)] = geometry
+                else: # If we don't have the cell IDs we will have to infer
+                    if len(unique_cells) < len(polygon_json['geometries']):
+                        raise ValueError("Number of cells in input file exceeds SpotTable")
+                        
+                    # This method ensure compatibility with both JSONs which store None and those which dont
+                    valid_cells = [cid for cid in unique_cells if len(self.cell_indices(cid)) > 3]
+                    invalid_cells = [cid for cid in unique_cells if len(self.cell_indices(cid)) <= 3]
+                    
+                    for geometry in tqdm(polygon_json['geometries'], disable=disable_tqdm):
+                        if geometry and geometry['type'] == 'Polygon':
+                            polygon = Polygon(geometry['coordinates'][0])
+                            self.cell_polygons[valid_cells.pop(0)] = polygon
+                        elif not geometry:
+                            self.cell_polygons[invalid_cells.pop(0)] = geometry
             else:
                 raise ValueError('geojson type must be FeatureCollection or GeometryCollection')
         else:


### PR DESCRIPTION
Realized that there was a bug with loading 2d cell polygons in after doing a distributed calculation using SegmenationPipeline. 
Previously when 2D polygons were loaded in, they would be assigned to the cell ids in sorted order since GeometeryCollections don't support IDs. However, if you do distributed cell polygon calculation, then it will just keep assigning polygons to the same cell ids at the beginning of the list. 
Now, you can provide a `[Path/str/list/np.ndarray]` of cell ids to `SpotTable.load_cell_polygons()` for the polygons to be assigned to.

In order to support this change to `SpotTable`, `SegmentationPipeline.merge_cell_polygons()` now passes the cell polygon subset file to `SpotTable.load_cell_polygons()`