### PR TITLE
sst.load_npz properly loads None production_ids

### DIFF
--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -2030,7 +2030,7 @@ class SegmentedSpotTable:
         sst_fields = {
             'cell_ids': fields['cell_ids'],
             'seg_metadata': fields['seg_metadata'].item(),
-            'production_cell_ids': fields['production_cell_ids'],
+            'production_cell_ids': fields['production_cell_ids'].item() if np.any(fields['production_cell_ids']) is None else fields['production_cell_ids'],
             'pcid_to_cid': fields['_pcid_to_cid'].item(),
             'cid_to_pcid': fields['_cid_to_pcid'].item(),
             'cell_polygons': fields['cell_polygons'].item()


### PR DESCRIPTION
If you had a `SegmentedSpotTable` named `sst` with `sst.production_cell_ids = None` and saved it to disk using `sst.save_npz()` and then loaded that spot table back into memory using `sst = SegmentedSpotTable.load_npz()` you would get `sst.production_cell_ids == array(None, dtype=object)`. This would cause issues downstream as we expect `sst.production_cell_ids` to be `None` if there are no cell ids.

This new approach uses `np.any()` to check if the production cell ids in the spot table being loaded are not None. 