### PR TITLE
change dtype of stereoseq counts

### DIFF
--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -447,7 +447,7 @@ class SpotTable:
           
                 raw_data = np.loadtxt(lines, usecols=usecols, delimiter='\t', dtype=dtype)
                 end = fh.tell()
-                counts = np.asarray(raw_data['MIDcounts'], dtype='uint8')
+                counts = np.asarray(raw_data['MIDcounts'], dtype='uint64')
                 pos2 = np.empty((sum(counts), 2), dtype='float64')
                 pos2[:, 0] = np.repeat(raw_data['x'] * xyscale, counts)
                 pos2[:, 1] = np.repeat(raw_data['y'] * xyscale, counts)


### PR DESCRIPTION
In read_stereoseq_gem the raw counts were getting loaded in as `uint8` which didn't reserve enough bits for building out the full position array. Upped it to `uint64` which should be sufficient