### PR TITLE
added shapely.validation.make_valid call to sis.SegmentedSpotTable.cell_polygon

### DIFF
--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -12,7 +12,7 @@ geojson = optional_import('geojson')
 shapely = optional_import('shapely')
 MultiLineString = optional_import('shapely.geometry', names=['MultiLineString'])[0]
 unary_union, polygonize = optional_import('shapely.ops', ['unary_union', 'polygonize'])
-make_valid = optional_import('shapely.validation', ['make_valid'])
+make_valid = optional_import('shapely.validation', names=['make_valid'])[0]
 
 from .image import ImageBase, ImageFile, ImageStack, ImageTransform
 from . import util


### PR DESCRIPTION
Steph ran into the following error when trying to generate polygons for a stereoseq segmentation.
```
Traceback (most recent call last):
    File "/tmp/nxf.xGhdu42cUP/capsule/code/run.py", line 17, in <module>
      func(*args, **kwargs)
    File "/src/spots-in-space/sis/spot_table.py", line 52, in run_cell_polygon_calculation
      seg_spot_table.calculate_cell_polygons(cells_to_run=cells_to_run, alpha_inv_coeff=alpha_inv_coeff, separate_z_planes=separate_z_planes)
    File "/src/spots-in-space/sis/spot_table.py", line 1547, in calculate_cell_polygons
      self.cell_polygons[cid] = self.calculate_optimal_polygon(xy_pos, alpha_inv, alpha_inv_coeff=alpha_inv_coeff)
    File "/src/spots-in-space/sis/spot_table.py", line 1514, in calculate_optimal_polygon
      putative_polygon = SegmentedSpotTable.cell_polygon(xy_pos, flex_alpha_inv)
    File "/src/spots-in-space/sis/spot_table.py", line 1488, in cell_polygon
      tp = unary_union(triangles)
    File "/opt/conda/lib/python3.10/site-packages/shapely/ops.py", line 135, in unary_union
      return shapely.union_all(geoms, axis=None)
    File "/opt/conda/lib/python3.10/site-packages/shapely/decorators.py", line 77, in wrapped
      return func(*args, **kwargs)
    File "/opt/conda/lib/python3.10/site-packages/shapely/set_operations.py", line 421, in union_all
      return lib.unary_union(collections, **kwargs)
  shapely.errors.GEOSException: TopologyException: side location conflict at 12581 15768.5. This can occur if the input geometry is invalid.
```

After looking into the error I determined it was caused by one of the triangles that made up the total cell polygon geometry being malformed. 
![image](https://github.com/user-attachments/assets/650a34ec-760b-45dd-9cb3-99b3cfbd3e56)
I'm not sure why polygonize does this, but it can be fixed by making a call to `shapely.validation.make_valid` for each of the shapely polygons. Invalid polygons become Multipolygons which can be fed into `shapely.ops.unary_union` without issue.
![image](https://github.com/user-attachments/assets/52c08ba3-c3db-4383-8d36-21a75ac16b04)
