### PR TITLE
Fixed improper caching of `SegmentedSpotTable._unique_cell_ids`

### DIFF
--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1204,7 +1204,6 @@ class SegmentedSpotTable:
                     warnings.warn("Some cells were modified, removed, or created. Cell polygons have been kept for unchanged cells but removed for modified, removed, or created cells.")
         self._old_cell_ids = None
         
-    @property
     def unique_cell_ids(self):
         """numpy array of unique cell ids (excluding background)
         """
@@ -1244,11 +1243,11 @@ class SegmentedSpotTable:
             prefix = ''
             
         # Create dictionary to map cell ids to production ids 
-        cid_to_pcid = dict(zip(self.unique_cell_ids, np.char.mod(f'{prefix}%d{suffix}', np.arange(1, len(self.unique_cell_ids)+1))))
+        cid_to_pcid = dict(zip(self.unique_cell_ids(), np.char.mod(f'{prefix}%d{suffix}', np.arange(1, len(self.unique_cell_ids())+1))))
         cid_to_pcid[-1] = "-1"
     
         # Create dictionary to map production cell ids to cell ids 
-        pcid_to_cid = dict(zip(np.char.mod(f'{prefix}%d{suffix}', np.arange(1, len(self.unique_cell_ids)+1)), self.unique_cell_ids)) 
+        pcid_to_cid = dict(zip(np.char.mod(f'{prefix}%d{suffix}', np.arange(1, len(self.unique_cell_ids())+1)), self.unique_cell_ids())) 
         pcid_to_cid["-1"] = -1
     
         # Reset the current production cell ids and before we call cell_ids_changed for speed
@@ -1414,7 +1413,7 @@ class SegmentedSpotTable:
     def cell_centroids(self, use_production_ids=False):
         """Return a Pandas DataFrame of cell centroids calculated mean of the x,y,z coordinates for each cell."""
         centroids = []
-        for cid in self.unique_cell_ids:
+        for cid in self.unique_cell_ids():
             inds = self.cell_indices(cid)
             cell_ts_xyz = self.pos[inds]
             centroids.append(np.mean(cell_ts_xyz, axis=0))
@@ -1425,7 +1424,7 @@ class SegmentedSpotTable:
             empty[:] = np.nan
             centroids = np.append(centroids, empty, axis=1)
             
-        indices = [self.convert_cell_id(cid) for cid in self.unique_cell_ids] if use_production_ids else self.unique_cell_ids
+        indices = [self.convert_cell_id(cid) for cid in self.unique_cell_ids()] if use_production_ids else self.unique_cell_ids()
         return pandas.DataFrame(data=centroids, index=indices, columns=['center_x', 'center_y', 'center_z'])
 
     @staticmethod


### PR DESCRIPTION
`SegmentedSpotTable.unique_cell_ids()` was calculating the unique cell ids with np.unique() every time it was called. The intended behavior is to calculate and cache the unique cell ids the first time it is called and then simply return the cached value every subsequent time it is called. This has now been fixed.

I considered turning `SegmentedSpotTable.unique_cell_ids()` into a property with the `@property` decorator but decided against it for now in order to maintain backwards compatibility.