### PR TITLE
implementing SegmentedSpotTable__setattr__ & adding setters for SpotTable properties

### DIFF
--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1586,9 +1586,17 @@ class SegmentedSpotTable:
         If it is, it will set it there (where it can be properly accessed
         by SpotTable functions). If not, it will set the attribute in SegmentedSpotTable.
         """
-        if hasattr(self.spot_table, name):# check if the value exists in spot_table
-            setattr(self.spot_table, name, value) # if it does, we'll set it there
-        else: # if it doesn't, we'll set it here
+        if name == "spot_table" or "spot_table" not in self.__dict__:
+            # During __init__, or if setting spot_table itself, set attribute normally
+            super().__setattr__(name, value)
+        elif hasattr(self, name):
+            # We first check locally for the attribute and set here if it exists
+            super().__setattr__(name, value)
+        elif hasattr(self.spot_table, name):
+            # If the attribute exists in SpotTable, set it there
+            setattr(self.spot_table, name, value)
+        else:
+            # In all other cases, set attribute locally
             super().__setattr__(name, value)
             
     def __delattr__(self, name: str) -> None:
@@ -1597,9 +1605,17 @@ class SegmentedSpotTable:
         this method will first check if that attribute is found in SpotTable.
         If it is, it will delete it there. If not, it will delete it here.
         """
-        if hasattr(self.spot_table, name): # check if the value exists in spot_table
-            delattr(self.spot_table, name) # if it does, we'll delete it there
-        else: # if it doesn't, we'll delete it here
+        if name == "spot_table" or "spot_table" not in self.__dict__:
+            # During __init__, or if deleting spot_table itself, delete attribute normally
+            super().__delattr__(name)
+        elif hasattr(self, name):
+            # We first check locally for the attribute and delete here if it exists
+            super().__delattr__(name)
+        elif hasattr(self.spot_table, name):
+            # If the attribute exists in SpotTable, delete it there
+            delattr(self.spot_table, name)
+        else:
+            # In all other cases, delete attribute locally
             super().__delattr__(name)
 
     def __getitem__(self, item: np.ndarray):

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os, json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from scipy.spatial import Delaunay
@@ -1577,6 +1578,29 @@ class SegmentedSpotTable:
             raise
 
         return attr
+    
+    def __setattr__(self, name: str, value: Any):
+        """This method enables SegmentedSpotTable to act as a proxy for
+        attributes in SpotTable. Anytime the user attempts to set an attribute,
+        this method will first check if that attribute is found in SpotTable.
+        If it is, it will set it there (where it can be properly accessed
+        by SpotTable functions). If not, it will set the attribute in SegmentedSpotTable.
+        """
+        if hasattr(self.spot_table, name):# check if the value exists in spot_table
+            setattr(self.spot_table, name, value) # if it does, we'll set it there
+        else: # if it doesn't, we'll set it here
+            super().__setattr__(name, value)
+            
+    def __delattr__(self, name: str) -> None:
+        """This method enables SegmentedSpotTable to act as a proxy for
+        attributes in SpotTable. Anytime the user attempts to delete an attribute,
+        this method will first check if that attribute is found in SpotTable.
+        If it is, it will delete it there. If not, it will delete it here.
+        """
+        if hasattr(self.spot_table, name): # check if the value exists in spot_table
+            delattr(self.spot_table, name) # if it does, we'll delete it there
+        else: # if it doesn't, we'll delete it here
+            super().__delattr__(name)
 
     def __getitem__(self, item: np.ndarray):
         """Return a subset of this SegmentedSpotTable.

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -195,7 +195,7 @@ class SpotTable:
             raise Exception("Must specify either gene_names or gene_ids")
 
         self._gene_names = None
-        self._unique_genes_names = None
+        self._unique_gene_names = None
 
         self.images = []
         if images is None:
@@ -277,7 +277,7 @@ class SpotTable:
         except KeyError as e:
             raise KeyError(f"{e} missing from self.gene_name_to_id mapping. Cannot set gene_names without first updating mapping to include all new genes.")
         self._gene_names = names
-        self._unique_genes_names = None # reset cached unique gene names
+        self._unique_gene_names = None # reset cached unique gene names
         
     @property
     def gene_ids(self):
@@ -304,7 +304,7 @@ class SpotTable:
         
         self._gene_ids = ids
         self._gene_names = None # reset cached gene names
-        self._unique_genes_names = None # reset cached unique gene names
+        self._unique_gene_names = None # reset cached unique gene names
     
     @property
     def gene_id_to_name(self):
@@ -332,7 +332,7 @@ class SpotTable:
         self._gene_id_to_name = id_to_name
         self._gene_name_to_id = {name:id for id,name in enumerate(self._gene_id_to_name)}
         self._gene_names = None # reset cached gene names
-        self._unique_genes_names = None # reset cached unique gene names
+        self._unique_gene_names = None # reset cached unique gene names
 
     @property
     def gene_name_to_id(self):
@@ -354,7 +354,7 @@ class SpotTable:
             Array mapping from gene names to gene IDs.
         """
         # Check that all gene names in the table are present in the new mapping
-        for gene in self.unique_genes_names:
+        for gene in self.unique_gene_names:
             assert gene in name_to_id, f"Gene name: {gene} not found in new name_to_id mapping."
             
         self._gene_name_to_id = name_to_id
@@ -367,10 +367,10 @@ class SpotTable:
         self._gene_id_to_name = id_to_name
         
         self._gene_names = None # reset cached gene names
-        self._unique_genes_names = None # reset cached unique gene names
+        self._unique_gene_names = None # reset cached unique gene names
 
     @property
-    def unique_genes_names(self):
+    def unique_gene_names(self):
         """Return the unique gene names in the SpotTable.
         
         Returns
@@ -378,15 +378,15 @@ class SpotTable:
         numpy.ndarray
             Array of unique gene names.
         """
-        if self._unique_genes_names is None: # If we don't have the unique gene names cached, we need to create them
-            self._unique_genes_names = np.sort(pandas.Series(self.gene_names).unique()) # Faster than np.unique
-        return self._unique_genes_names
+        if self._unique_gene_names is None: # If we don't have the unique gene names cached, we need to create them
+            self._unique_gene_names = np.sort(pandas.Series(self.gene_names).unique()) # Faster than np.unique
+        return self._unique_gene_names
     
-    @unique_genes_names.setter
-    def unique_genes_names(self, names):
+    @unique_gene_names.setter
+    def unique_gene_names(self, names):
         """Setter to make sure we don't set unique_cell_ids directly.
         """
-        raise ValueError("unique_genes_names cannot be set directly. Use gene_names instead.")
+        raise ValueError("unique_gene_names cannot be set directly. Use gene_names instead.")
 
     @property
     def x(self):

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -180,15 +180,15 @@ class SpotTable:
             # gene_names are specified, so we need to create gene_ids and name/id mappings
             assert gene_ids is None and gene_id_to_name is None
             gene_ids, gene_to_id, id_to_gene = self._make_gene_index(gene_names)
-            self.gene_ids = gene_ids
-            self.gene_name_to_id = gene_to_id
-            self.gene_id_to_name = id_to_gene
+            self._gene_ids = gene_ids
+            self._gene_name_to_id = gene_to_id
+            self._gene_id_to_name = id_to_gene
         elif gene_ids is not None:
             # gene_id and id to name mappings are specified so we need to create name to id mappings
             assert gene_id_to_name is not None
-            self.gene_ids = gene_ids
-            self.gene_id_to_name = gene_id_to_name
-            self.gene_name_to_id = {name:id for id,name in enumerate(self.gene_id_to_name)}
+            self._gene_ids = gene_ids
+            self._gene_id_to_name = gene_id_to_name
+            self._gene_name_to_id = {name:id for id,name in enumerate(self.gene_id_to_name)}
         else:
             raise Exception("Must specify either gene_names or gene_ids")
 
@@ -263,6 +263,81 @@ class SpotTable:
         if self._gene_names is None:
             self._gene_names = self.map_gene_ids_to_names(self.gene_ids)
         return self._gene_names
+    
+    @gene_names.setter
+    def gene_names(self, names):
+        self._gene_names = names
+        # have to update underlying ids as well
+        self._gene_ids = self.map_gene_names_to_ids(names)
+        
+
+    @property
+    def gene_ids(self):
+        """Return an array of gene IDs corresponding to the spots in the SpotTable.
+        
+        Returns
+        -------
+        self._gene_ids : numpy.ndarray
+        """
+        return self._gene_ids
+    
+    @gene_ids.setter
+    def gene_ids(self, ids):
+        """Set the gene IDs for the spots in the SpotTable.
+        
+        Parameters
+        ----------
+        ids : numpy.ndarray
+            Array of gene IDs to set.
+        """
+        self._gene_ids = ids
+        self._gene_names = None # reset cached gene names
+    
+    @property
+    def gene_id_to_name(self):
+        """Return an array mapping from gene IDs to gene names.
+        
+        Returns
+        -------
+        self._gene_id_to_name : numpy.ndarray
+        """
+        return self._gene_id_to_name
+    
+    @gene_id_to_name.setter
+    def gene_id_to_name(self, id_to_name):
+        """Set the mapping from gene IDs to gene names.
+        
+        Parameters
+        ----------
+        id_to_name : numpy.ndarray
+            Array mapping from gene IDs to gene names.
+        """
+        self._gene_id_to_name = id_to_name
+        self._gene_name_to_id = {name:id for id,name in enumerate(self._gene_id_to_name)}
+        self._gene_names = None # reset cached gene names
+
+    @property
+    def gene_name_to_id(self):
+        """Return an array mapping from gene IDs to gene names.
+        
+        Returns
+        -------
+        self._gene_name_to_id : numpy.ndarray
+        """
+        return self._gene_name_to_id
+    
+    @gene_name_to_id.setter
+    def gene_name_to_id(self, name_to_id):
+        """Set the mapping from gene IDs to gene names.
+        
+        Parameters
+        ----------
+        name_to_id : numpy.ndarray
+            Array mapping from gene names to gene IDs.
+        """
+        self._gene_name_to_id = name_to_id
+        self._gene_id_to_name = {id:name for id,name in enumerate(self._gene_name_to_id)}
+        self._gene_names = None # reset cached gene names
 
     @property
     def x(self):
@@ -273,6 +348,17 @@ class SpotTable:
         self.pos[:, 0] : numpy.ndarray
         """
         return self.pos[:, 0]
+    
+    @x.setter
+    def x(self, coords):
+        """Set the x-coordinates of the spots in the SpotTable.
+        
+        Parameters
+        ----------
+        coords : numpy.ndarray
+            Array of x-coordinates to set.
+        """
+        self.pos[:, 0] = coords
 
     @property
     def y(self):
@@ -290,6 +376,19 @@ class SpotTable:
         else:
             return self.pos[:, 1]
 
+    @y.setter
+    def y(self, coords):
+        """Set the y-coordinates of the spots in the SpotTable.
+        
+        Parameters
+        ----------
+        coords : numpy.ndarray
+            Array of y-coordinates to set.
+        """
+        if self.pos.shape[1] < 2:
+            raise ValueError("Cannot set y-coordinates: SpotTable has no y-coordinates.")
+        self.pos[:, 1] = coords
+
     @property
     def z(self):
         """Return the z-coordinates of the spots in the SpotTable.
@@ -305,6 +404,19 @@ class SpotTable:
             return None
         else:
             return self.pos[:, 2]
+        
+    @z.setter
+    def z(self, coords):
+        """Set the z-coordinates of the spots in the SpotTable.
+        
+        Parameters
+        ----------
+        coords : numpy.ndarray
+            Array of z-coordinates to set.
+        """
+        if self.pos.shape[1] < 3:
+            raise ValueError("Cannot set z-coordinates: SpotTable has no z-coordinates.")
+        self.pos[:, 2] = coords
 
     def map_gene_names_to_ids(self, names):
         """Map gene names to gene IDs.

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -380,7 +380,7 @@ class SpotTable:
         """
         if self._unique_genes_names is None: # If we don't have the unique gene names cached, we need to create them
             self._unique_genes_names = np.sort(pandas.Series(self.gene_names).unique()) # Faster than np.unique
-        return self._unique_cell_ids
+        return self._unique_genes_names
     
     @unique_genes_names.setter
     def unique_genes_names(self, names):

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1589,8 +1589,9 @@ class SegmentedSpotTable:
         if name == "spot_table" or "spot_table" not in self.__dict__:
             # During __init__, or if setting spot_table itself, set attribute normally
             super().__setattr__(name, value)
-        elif hasattr(self, name):
-            # We first check locally for the attribute and set here if it exists
+        elif name in self.__dict__.keys(): 
+            # we first check locally for the attribute and set here if it exists
+            # Cannot use hasattr here because it calls __getattr__ which will return SpotTable attributes
             super().__setattr__(name, value)
         elif hasattr(self.spot_table, name):
             # If the attribute exists in SpotTable, set it there
@@ -1608,8 +1609,9 @@ class SegmentedSpotTable:
         if name == "spot_table" or "spot_table" not in self.__dict__:
             # During __init__, or if deleting spot_table itself, delete attribute normally
             super().__delattr__(name)
-        elif hasattr(self, name):
+        elif name in self.__dict__.keys(): 
             # We first check locally for the attribute and delete here if it exists
+            # Cannot use hasattr here because it calls __getattr__ which will return SpotTable attributes
             super().__delattr__(name)
         elif hasattr(self.spot_table, name):
             # If the attribute exists in SpotTable, delete it there

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -350,22 +350,22 @@ class SpotTable:
 
     @property
     def gene_name_to_id(self):
-        """Return a dictionary mapping from gene IDs to gene names.
+        """Return a dictionary mapping from gene names to gene IDs.
         
         Returns
         -------
-        self._gene_name_to_id : numpy.ndarray
+        self._gene_name_to_id : dict
         """
         return self._gene_name_to_id
     
     @gene_name_to_id.setter
     def gene_name_to_id(self, name_to_id):
-        """Set the mapping from gene IDs to gene names.
+        """Set the mapping from gene names to gene IDs.
         
         Parameters
         ----------
-        name_to_id : numpy.ndarray
-            Array mapping from gene names to gene IDs.
+        name_to_id : dict
+            Dictionary mapping from gene names to gene IDs.
         """
         # Check that all gene names in the table are present in the new mapping
         for gene in self.unique_gene_names:

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -99,7 +99,10 @@ class SpotTable:
     gene_ids : numpy.ndarray
         Array of shape (N,) describing the gene detected in each transcript, as an index into *gene_id_to_name*.
     gene_id_to_name: numpy.ndarray
-        Array mapping from values in *gene_ids* to string names.
+        Array mapping from values in *gene_ids* to string names. 
+        This attribute is not intended to be modified inplace via indexing, doing so may lead to unexpected behavior. 
+        To modify the gene_id_to_name mapping, use the gene_id_to_name setter, which will also update
+        the gene_name_to_id mapping and reset cached gene names.
     gene_name_to_id : dict
         Dictionary mapping from gene names to gene IDs.
     _gene_names : numpy.ndarray
@@ -336,7 +339,7 @@ class SpotTable:
 
     @property
     def gene_name_to_id(self):
-        """Return an array mapping from gene IDs to gene names.
+        """Return a dictionary mapping from gene IDs to gene names.
         
         Returns
         -------
@@ -498,10 +501,7 @@ class SpotTable:
         out : array
             Array of gene names corresponding to the input gene IDs.
         """
-        out = np.empty(len(ids), dtype=self.gene_id_to_name.dtype)
-        for i,id in enumerate(ids):
-            out[i] = self.gene_id_to_name[id]
-        return out
+        return self.gene_id_to_name[ids]
 
         
     def bounds(self):


### PR DESCRIPTION
When I was working with SegmentedSpotTable recently, I discovered a bug to do with setting variables which are stored in `SegmentedSpotTable.spot_table`. These values get retrieved via `__getattr__`, but cannot be set. And in fact if you try and set them, you will create a duplicate variable stored in the SegmentedSpotTable itself, not `SegmentedSpotTable.spot_table`. 

Here is an example in jupyterlab:
<img width="1173" height="592" alt="image" src="https://github.com/user-attachments/assets/d00f2aa8-7c4b-4f5a-898c-90aa674e8327" />

In order to fix this, we must implement SegmentedSpotTable's `__setattr__` function. This is a special method in python that all classes have which intercepts any attempts to assign class attributes. By modifying it from its base functionality, we can check whether any attribute we're trying to set exists in `SegmentedSpotTable.spot_table` and set it there instead of locally. I also implemented the related `__delattr__` for consistency.

While implementing these changes, I ran into some issues setting some of the properties in SpotTable. As such, I created setters for `x`, `y`, `z`, `gene_names`, `gene_ids`, `gene_name_to_id`, and `gene_id_to_name`.

Here is a full list of changes in the PR:

- SegmentedSpotTable
    - `__setattr__`
        - Added dunder function which will attempt to set attributes in the underlying `spot_table` if they exist there and not in the `SegmentedSpotTable` itself
    - `__delattr__`
        - Companion function to `__getattr__` and `__setattr__` which functions under the same logic as `__setattr__`
- SpotTable
    - `gene_names`
        - added a setter that ensures that the shape matches and update `gene_ids` with the changes
    - `gene_ids`
        - moved it from being a directly accessible instance variable to a property with an underlying `_gene_ids` variable and getter and setter
        - The setter ensures the shape & values are valid and also resets the `gene_names` values.
    - `gene_name_to_id`
        - moved it from being a directly accessible instance variable to a property with an underlying `_gene_name_to_id` variable and getter and setter
        - The setter ensures that all `gene_names` are represented in the new mapping, reconstructs the `gene_id_to_name` array, and resets `gene_names`
    - `gene_id_to_name`
        - moved it from being a directly accessible instance variable to a property with an underlying `_gene_id_to_name` variable and getter and setter
        - The setter ensures that all `gene_ids` are represented in the new mapping, reconstructs the `gene_name_to_id` dictionary, and resets `gene_names`
    - `unique_gene_names`
        - New property to allow for quick access to a sorted list of genes present in the `SpotTable` 
    - `x`
        - Now has a setter
    - `y`
        - Now has a setter
    - `z`
        - Now has a setter