### PR TITLE
Issue 86

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,5 @@ CI = "https://github.com/AllenInstitute/spots-in-space/actions"
 
 [project.optional-dependencies]
 cellpose = ["cellpose==3.0.7"]
-test = ["pytest", "spatialdata[extra]>=0.6.1", "cellpose==3.0.7"]
-spatialdata = ["spatialdata[extra]>=0.6.1"]
+test = ["pytest", "spatialdata[extra]>=0.7.0", "cellpose==3.0.7"]
+spatialdata = ["spatialdata[extra]>=0.7.0"]

--- a/sis/spatialdata.py
+++ b/sis/spatialdata.py
@@ -12,8 +12,6 @@ from shapely import MultiPolygon
 from xarray import concat, DataTree
 
 
-import dask
-dask.config.set({"dataframe.query-planning": False})
 import dask.array as da
 import dask.dataframe as dd
 from dask_image.imread import imread

--- a/sis/spatialdata.py
+++ b/sis/spatialdata.py
@@ -95,7 +95,6 @@ def _images_merscope(images_dir: str | Path,
     """
     import glob
     import re
-    dask.config.set({"dataframe.query-planning": False})
     
     if not isinstance(images_dir, Path):
         images_dir = Path(images_dir)
@@ -210,8 +209,6 @@ def _images_xenium(xenium_dir: str | Path,
     KeyError
         If aggregate_z is not a recognized string or callable function.
     """
-    dask.config.set({"dataframe.query-planning": False})
-    
     if not isinstance(xenium_dir, Path):
         xenium_dir = Path(xenium_dir)
     
@@ -279,7 +276,6 @@ def _polygons(features: geojson.FeatureCollection,
         geopandas dataframe of polygons to add to SpatialData object.
     """
     import warnings
-    dask.config.set({"dataframe.query-planning": False})
     
     # Find out if z-planes are in the geojson
     z_planes_present = "z_plane" in features['features'][0]
@@ -350,9 +346,7 @@ def _spottable(df: dd.DataFrame,
     -------
     transcripts : dask.dataframe.core.DataFrame
         Dask dataframe of transcripts to add to SpatialData object.
-    """
-    dask.config.set({"dataframe.query-planning": False})
-    
+    """    
     if z_planes:
         # Subset the dataframe to only include specified z_planes
         z_planes = [z_planes] if isinstance(z_planes, int) else z_planes
@@ -389,9 +383,7 @@ def _cell_by_gene(adata: anndata.AnnData) -> anndata.AnnData:
     -------
     anndata.AnnData
         Formatted anndata to add to SpatialData object.
-    """
-    dask.config.set({"dataframe.query-planning": False})
-    
+    """    
     try:
         # SIS stores cell polygons in the anndata
         # SpatialData already has them elsewhere, so lets remove them here
@@ -456,9 +448,7 @@ def merscope_to_spatialdata(images_dir: str | Path,
     ------
     ValueError
         If both sis_dir and spot_table are defined or both are None.
-    """
-    dask.config.set({"dataframe.query-planning": False})
-    
+    """    
     if (sis_dir is None) == (spot_table is None):
         raise ValueError('One and exactly one of sis_dir and spot_table should be defined')
 
@@ -565,9 +555,7 @@ def xenium_to_spatialdata(xenium_dir: str | Path,
     ------
     ValueError
         If both sis_dir and spot_table are defined or both are None.
-    """
-    dask.config.set({"dataframe.query-planning": False})
-    
+    """    
     if (sis_dir is None) == (spot_table is None):
         raise ValueError('One and exactly one of sis_dir and spot_table should be defined')
 

--- a/sis/spatialdata.py
+++ b/sis/spatialdata.py
@@ -16,16 +16,10 @@ from .optional_import import optional_import
 
 concat, DataTree = optional_import('xarray', names=['concat', 'DataTree'])
 
-<<<<<<< issue_86
-import dask.array as da
-import dask.dataframe as dd
-from dask_image.imread import imread
-=======
 dask = optional_import('dask')
 da = optional_import('dask.array')
 dd = optional_import('dask.dataframe')
 imread = optional_import('dask_image.imread', names=['imread'])[0]
->>>>>>> main
 
 SpatialData = optional_import('spatialdata', names=['SpatialData'])[0]
 _get_channel_names = optional_import('spatialdata_io.readers.merscope', names=['_get_channel_names'])[0]

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -3006,7 +3006,7 @@ class SegmentedSpotTable:
         sis.spot_table.SegmentedSpotTable
         """
         # Read in the positions
-        raw_spot_table = SpotTable.load_xenium(transcript_file=transcript_file, cache_file=cache_file, image_path=image_path, max_rows=max_rows, z_depth=z_depth, pyramid_level=pyramid_level, cache_image=cache_image)
+        raw_spot_table = SpotTable.load_xenium(transcript_file=transcript_file, cache_file=cache_file, image_path=image_path, max_rows=max_rows, z_depth=z_depth, min_qv=min_qv, pyramid_level=pyramid_level, cache_image=cache_image)
 
         # Read in the cell ids
         if str(transcript_file).endswith('.csv') or str(transcript_file).endswith('.csv.gz'):

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1570,7 +1570,7 @@ class SpotTable:
         return cls(pos=pos, gene_names=gene_names, images=images)
 
     @classmethod
-    def _load_xenium_spatialdata_internal(cls, sd_object: spatialdata.SpatialData, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
+    def _load_xenium_spatialdata_internal(cls, sd_object: spatialdata.SpatialData, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=20, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
         """Contains all the logic for load_xenium_spatialdata but returns a min_qv mask.
         This reduces duplicate code while allowing _load_spatialdata_cids_polygons to access the min_qv mask
         See load_xenium_spatialdata docstring for explanation of function
@@ -1644,7 +1644,7 @@ class SpotTable:
         return cls(pos=pos, gene_names=gene_names, images=image, xenium_min_qv=min_qv), mask
 
     @classmethod
-    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
+    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=20, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
         """Take a xenium spatialdata file or object and load its data into a SpotTable
         The spatialdata object should follow the xenium convention as defined in spatialdata-io.xenium()
         
@@ -3560,7 +3560,7 @@ class SegmentedSpotTable:
         return cls._load_spatialdata_cids_polygons(raw_spot_table, sd_object, points_name, shapes_name, cell_id_col, seg_method, use_original_cell_ids, set(['-1']))
     
     @classmethod
-    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, shapes_name: str|None=None, cell_id_col: str|None=None, gene_col: str|None='feature_name', seg_method: str|None=None, use_original_cell_ids: bool=False):
+    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=20, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, shapes_name: str|None=None, cell_id_col: str|None=None, gene_col: str|None='feature_name', seg_method: str|None=None, use_original_cell_ids: bool=False):
         """Take a xenium spatialdata file or object and load its data into a SegmentedSpotTable
         The spatialdata object should follow the Xenium convention as defined in spatialdata-io.xenium()
 

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -3369,7 +3369,7 @@ class SegmentedSpotTable:
 
         cell_by_gene = seg_spot_table.cell_by_gene_anndata(x_format=x_format, additional_obs=additional_obs)
         for col, dtype in cell_by_gene.obs.dtypes.items():
-            if dtype.kind == 'i' and col in additional_obs.keys() and cell_by_gene.obs[col].nunique() > 1:
+            if dtype.kind == 'i' and additional_obs is not None and col in additional_obs.keys() and cell_by_gene.obs[col].nunique() > 1:
                 # We make additional integer columns with dynamic values into pandas Int64 so they can handle nan types
                 # We don't have to do so for ones with singular values since those will get copied to the transcriptless cells
                 # Also don't have to do so for standard columns (that are integer) since the transcriptless cells get values for those

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -3369,7 +3369,7 @@ class SegmentedSpotTable:
 
         cell_by_gene = seg_spot_table.cell_by_gene_anndata(x_format=x_format, additional_obs=additional_obs)
         for col, dtype in cell_by_gene.obs.dtypes.items():
-            if dtype.kind == 'i' and col in additional_obs.keys() and len(cell_by_gene.obs[col].unique()) > 1:
+            if dtype.kind == 'i' and col in additional_obs.keys() and cell_by_gene.obs[col].nunique() > 1:
                 # We make additional integer columns with dynamic values into pandas Int64 so they can handle nan types
                 # We don't have to do so for ones with singular values since those will get copied to the transcriptless cells
                 # Also don't have to do so for standard columns (that are integer) since the transcriptless cells get values for those
@@ -3387,11 +3387,12 @@ class SegmentedSpotTable:
         df['segmentation_job_id'] = cell_by_gene.obs['segmentation_job_id'].iloc[0]
         if additional_obs is not None:
             for column in additional_obs.keys():
-                if len(cell_by_gene.obs[column].unique()) == 1:
+                if cell_by_gene.obs[column].nunique() == 1:
                     df[column] = cell_by_gene.obs[column].iloc[0]
         
         # Append to anndata
-        new_X = scipy.sparse.vstack((cell_by_gene.X, scipy.sparse.csr_matrix((len(transcriptless_cells), cell_by_gene.X.shape[1]), dtype=cell_by_gene.X.dtype)))
+        empty_sparse = scipy.sparse.csr_matrix((len(transcriptless_cells), cell_by_gene.X.shape[1]), dtype=cell_by_gene.X.dtype)
+        new_X = scipy.sparse.vstack((cell_by_gene.X, empty_sparse))
         new_obs = pandas.concat([cell_by_gene.obs, df.astype(cell_by_gene.obs.dtypes)], axis=0)
         cell_by_gene = anndata.AnnData(new_X, obs=new_obs, var=cell_by_gene.var, uns=cell_by_gene.uns)
 

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -105,6 +105,10 @@ class SpotTable:
         Cached array of gene names corresponding to the gene IDs in the SpotTable.
     images : list[ImageBase]
         Image(s) associated with the data (e.g. nuclei stain).
+    _xenium_min_qv : float or None
+        Minimum quality value (Q-Score) for transcripts stored in this spot table. 
+        Only relevant for Xenium data, where it corresponds to the 'qv' column in the transcripts file.
+        See https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
 
     Methods
     -------
@@ -149,6 +153,7 @@ class SpotTable:
                  parent_inds: None|np.ndarray=None, 
                  parent_region: None|tuple=None,
                  images: None|list[ImageBase]|ImageBase=None,
+                 xenium_min_qv: None|float=None,
                  ):
         """
         Parameters
@@ -169,6 +174,10 @@ class SpotTable:
             X,Y boundaries ((xmin, xmax), (ymin, ymax)) used to select this table from the parent table.
         images : list[ImageBase] or ImageBase or None, optional
             Image(s) associated with the data (e.g. nuclei stain).
+        xenium_min_qv : float or None
+            Minimum quality value (Q-Score) for stored transcripts in this spot table.
+            Only relevant for Xenium data, where it corresponds to the 'qv' column in the transcripts file.
+            See https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
         """
         self.pos = pos
         self.parent_table = parent_table
@@ -203,6 +212,8 @@ class SpotTable:
                 self.add_image(img)
         else:
             raise TypeError(f'Unsupported type for image(s). Images must be of type ImageBase or a list of ImageBase.')
+
+        self._xenium_min_qv = xenium_min_qv
 
     def __len__(self):
         return len(self.pos)
@@ -304,6 +315,14 @@ class SpotTable:
             return None
         else:
             return self.pos[:, 2]
+        
+    @property
+    def xenium_min_qv(self):
+        """Return the minimum quality value (Q-Score) for stored transcripts in this spot table.
+        Only relevant for Xenium data, where it corresponds to the 'qv' column in the transcripts file.
+        See https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
+        """
+        return self._xenium_min_qv
 
     def map_gene_names_to_ids(self, names):
         """Map gene names to gene IDs.
@@ -786,7 +805,7 @@ class SpotTable:
 
 
     @staticmethod
-    def read_xenium_transcripts(transcript_file, max_rows=None, z_depth: float=3.0):
+    def read_xenium_transcripts(transcript_file, max_rows=None, z_depth: float=3.0, min_qv: float|None=20):
         """Helper function to read a Xenium transcripts file. (currently supports only csv and parquet)
         Intended to reduce duplicated code between SpotTable.load_xenium()
         and SegmentedSpotTable.load_xenium().
@@ -800,6 +819,9 @@ class SpotTable:
         z_depth : float, optional
             Depth (in um) of a imaging layer i.e. z-plane
             Used to bin z-positiions into discrete planes
+        min_qv : float, optional
+            Minimum quality value (Q-Score) for transcripts to be kept
+            See qv in https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
             
         Returns
         -------
@@ -816,6 +838,9 @@ class SpotTable:
         else:
             raise ValueError(f"Unsupported file type for transcript_file: {transcript_file}. Must be .csv, .csv.gz, or .parquet")
 
+        if min_qv is not None:
+            spot_dataframe = spot_dataframe[spot_dataframe['qv'] >= min_qv]
+        
         pos= spot_dataframe.loc[:,["x_location","y_location","z_location"]].values
         
         # Xenium z-values are continuous. For image operations, we bin float z locations to integers
@@ -828,7 +853,7 @@ class SpotTable:
     
     
     @classmethod
-    def load_xenium(cls, transcript_file: str, cache_file: str|None=None, image_path: str=None, max_rows: int=None, z_depth: float=3.0, pyramid_level: int=0, cache_image: bool=True):
+    def load_xenium(cls, transcript_file: str, cache_file: str|None=None, image_path: str=None, max_rows: int=None, z_depth: float=3.0, min_qv: float|None=20, pyramid_level: int=0, cache_image: bool=True):
         """Load Xenium data from a detected transcripts CSV file.
             This is the preferred method for resegmentation. If you want the original Xenium
             segmentation, use SegmentedSpotTable.load_xenium.
@@ -849,6 +874,9 @@ class SpotTable:
         z_depth : float, optional
             Depth (in um) of a imaging layer i.e. z-plane
             Used to bin z-positiions into discrete planes
+        min_qv : float, optional
+            Minimum quality value (Q-Score) for transcripts to be kept
+            See qv in https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
         pyramid_level : int, optional
             Xenium images can have multiple resolutions stored in an image pyramid.
             This parameter specifies which level of the pyramid to load.
@@ -869,13 +897,13 @@ class SpotTable:
 
         if (cache_file is None) or (not Path(cache_file).exists()):
             print("Loading transcripts...")
-            pos, gene_names = SpotTable.read_xenium_transcripts(transcript_file=transcript_file, max_rows=max_rows, z_depth=z_depth)
+            pos, gene_names = SpotTable.read_xenium_transcripts(transcript_file=transcript_file, max_rows=max_rows, z_depth=z_depth, min_qv=min_qv)
 
-            if cache_file is not None:                
+            if cache_file is not None:
                 print("Recompressing to npz..")
-                cls(pos=pos, gene_names=gene_names, images=images).save_npz(cache_file)
+                cls(pos=pos, gene_names=gene_names, images=images, xenium_min_qv=min_qv).save_npz(cache_file)
 
-            return cls(pos=pos, gene_names=gene_names, images=images)
+            return cls(pos=pos, gene_names=gene_names, images=images, xenium_min_qv=min_qv)
 
         else:
             print("Loading from npz..")
@@ -894,7 +922,8 @@ class SpotTable:
         fields = {
             'pos': self.pos,
             'gene_ids': self.gene_ids,
-            'gene_id_to_name': self.gene_id_to_name
+            'gene_id_to_name': self.gene_id_to_name,
+            'xenium_min_qv': self.xenium_min_qv if self.xenium_min_qv is not None else "None"
         }
         
         np.savez_compressed(npz_file, **fields) 
@@ -922,7 +951,8 @@ class SpotTable:
         pos = fields['pos']
         gene_ids = fields['gene_ids'] 
         gene_id_to_name = fields['gene_id_to_name']
-        return cls(pos=pos, gene_ids=gene_ids, gene_id_to_name=gene_id_to_name, images=images)
+        xenium_min_qv = fields['xenium_min_qv'] if fields['xenium_min_qv'] != "None" else None
+        return cls(pos=pos, gene_ids=gene_ids, gene_id_to_name=gene_id_to_name, images=images, xenium_min_qv=xenium_min_qv)
 
     def _make_gene_index(cls, gene_names):
         """Given an array of gene names, return an array of integer gene IDs and dictionaries
@@ -1540,7 +1570,7 @@ class SpotTable:
         return cls(pos=pos, gene_names=gene_names, images=images)
 
     @classmethod
-    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
+    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
         """Take a xenium spatialdata file or object and load its data into a SpotTable
         The spatialdata object should follow the xenium convention as defined in spatialdata-io.xenium()
         
@@ -1557,6 +1587,9 @@ class SpotTable:
         z_depth : float, optional
             The z depth to use when binning continuous z locations into integer z planes.
             Make sure to set this to 1.0 if your xenium data has already been binned to z planes.
+        min_qv : float or None, optional
+            The minimum quality value (Q-Score) for transcripts stored in this SpatialData object. 
+            If None, tries to pull from points table. If 'qv' column doesn't exist, will default to np.nan
         image_name : str, optional
             The name of the image to load from the spatial data. Or if morphology_path is provided, the name to assign to the morphology image.
         points_name : str, optional
@@ -1628,7 +1661,14 @@ class SpotTable:
             warnings.simplefilter("ignore")
             gene_names = sd_object[list(sd_object.points.keys())[0]][gene_col].to_dask_array().compute().astype(f'U{max_gene_len}')
 
-        return cls(pos=pos, gene_names=gene_names, images=image)
+        # read in the minimum QV if it exists, otherwise set to np.nan
+        if min_qv is None:
+            if 'qv' in sd_object[list(sd_object.points.keys())[0]].columns:
+                min_qv = sd_object[list(sd_object.points.keys())[0]]['qv'].min().compute()
+            else:
+                min_qv = np.nan
+
+        return cls(pos=pos, gene_names=gene_names, images=image, xenium_min_qv=min_qv)
 
 
 class SegmentedSpotTable:
@@ -2153,6 +2193,8 @@ class SegmentedSpotTable:
                     'cell_polygons': self.get_geojson_collection(use_cell_labels=True),
                     'SIS_repo_hash': _version.get_versions()['version'],
                     }
+        if self.xenium_min_qv is not None:
+            adata.uns['xenium_min_qv'] = self.xenium_min_qv
         return adata
 
 
@@ -2925,7 +2967,7 @@ class SegmentedSpotTable:
 
 
     @classmethod
-    def load_xenium(cls, transcript_file: str, cache_file: str|None=None, image_path: str|None=None, max_rows: int|None=None, z_depth: float=3.0, pyramid_level: int=0, cache_image: bool=True):
+    def load_xenium(cls, transcript_file: str, cache_file: str|None=None, image_path: str|None=None, max_rows: int|None=None, z_depth: float=3.0, min_qv: float|None=20, pyramid_level: int=0, cache_image: bool=True):
         """Load Xenium data from a detected transcripts CSV file, including
         the original segmentation. If you are resegmenting the data, prefer
         SpotTable.load_xenium.
@@ -2948,6 +2990,9 @@ class SegmentedSpotTable:
         z_depth : float, optional
             Depth (in um) of a imaging layer i.e. z-plane
             Used to bin z-positions into discrete planes
+        min_qv : float, optional
+            Minimum quality value (Q-Score) for transcripts to be kept
+            See qv in https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
         pyramid_level : int, optional
             Xenium images can have multiple resolutions stored in an image pyramid.
             This parameter specifies which level of the pyramid to load.
@@ -2965,13 +3010,17 @@ class SegmentedSpotTable:
 
         # Read in the cell ids
         if str(transcript_file).endswith('.csv') or str(transcript_file).endswith('.csv.gz'):
-            cell_ids = pandas.read_csv(transcript_file, nrows=max_rows, usecols=['cell_id']).values
+            cell_ids = pandas.read_csv(transcript_file, nrows=max_rows, usecols=['cell_id', 'qv'])
         elif str(transcript_file).endswith('.parquet'):
             if max_rows:
                 raise ValueError('max_rows is not supported for parquet files as pandas does not allow partial reading')
-            cell_ids = pandas.read_parquet(transcript_file, columns=['cell_id']).values
+            cell_ids = pandas.read_parquet(transcript_file, columns=['cell_id', 'qv'])
 
-        cell_ids = np.squeeze(cell_ids).astype(str) # Sometimes xenium ids are read in as bytes so just convert them now
+        if min_qv is not None:
+            cell_ids = cell_ids[cell_ids['qv'] >= min_qv]
+        cell_ids = cell_ids['cell_id'].values
+        
+        cell_ids = cell_ids.astype(str) # Sometimes xenium ids are read in as bytes so just convert them now
         cell_ids, cell_labels = cls._default_cell_ids(cell_ids, bg_ids=set(['UNASSIGNED']))
 
         spottable = cls(spot_table=raw_spot_table, cell_ids=cell_ids, seg_metadata={'seg_method': 'Xenium'})
@@ -3064,6 +3113,7 @@ class SegmentedSpotTable:
                 gene_ids=fields['gene_ids'],
                 gene_id_to_name=fields['gene_id_to_name'],
                 images=images
+                xenium_min_qv=fields['xenium_min_qv'] if fields['xenium_min_qv'] != "None" else None
                 )
         
         # handle underscores and object arrays
@@ -3091,6 +3141,7 @@ class SegmentedSpotTable:
             'gene_ids': self.gene_ids, 
             'gene_id_to_name': self.gene_id_to_name,
             'cell_ids': self.cell_ids,
+            'xenium_min_qv': self.xenium_min_qv if self.xenium_min_qv is not None else "None"
         }
 
         kwds = ['seg_metadata', 'cell_labels', '_cl_to_cid', '_cid_to_cl', 'cell_polygons']
@@ -3304,7 +3355,7 @@ class SegmentedSpotTable:
         return seg_subtable
     
     @classmethod
-    def save_xenium_kit_cbg(cls, expt_dir, output_file, max_rows: int|None=None, z_depth: float=3.0, x_format: str='sparse', additional_obs: dict|None=None):
+    def save_xenium_kit_cbg(cls, expt_dir, output_file, max_rows: int|None=None, z_depth: float=3.0, min_qv: float|None=20, x_format: str='sparse', additional_obs: dict|None=None):
         """Takes the results of a xenium experiment segmented with the Xenium segmentation kit
         and saves them into the SIS standard format
         
@@ -3319,6 +3370,9 @@ class SegmentedSpotTable:
         z_depth : float, optional
             Depth (in um) of a imaging layer i.e. z-plane
             Used to bin z-positions into discrete planes
+        min_qv : float, optional
+            Minimum quality value (Q-Score) for transcripts to be kept
+            See qv in https://www.10xgenomics.com/support/software/xenium-onboard-analysis/latest/analysis/xoa-output-understanding-outputs#transcript-file
         x_format : str, optional
             The format of the data matrix (X in the anndata), either 'dense' or 'sparse'.
         additional_obs : dict or None, optional
@@ -3336,7 +3390,7 @@ class SegmentedSpotTable:
         expt_dir = Path(expt_dir)
         transcript_file = expt_dir / 'transcripts.parquet'
         
-        seg_spot_table = cls.load_xenium(transcript_file=transcript_file, cache_file=None, image_path=expt_dir / 'morphology.ome.tif', max_rows=max_rows, z_depth=z_depth)
+        seg_spot_table = cls.load_xenium(transcript_file=transcript_file, cache_file=None, image_path=expt_dir / 'morphology.ome.tif', max_rows=max_rows, z_depth=z_depth, min_qv=min_qv)
         
         # Want to read in experiment metadata
         with open(expt_dir / 'experiment.xenium', 'r') as f:
@@ -3479,7 +3533,7 @@ class SegmentedSpotTable:
         return cls._load_spatialdata_cids_polygons(raw_spot_table, sd_object, points_name, shapes_name, cell_id_col, seg_method, use_original_cell_ids, set(['-1']))
     
     @classmethod
-    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, image_name: str='morphology', points_name: str|None=None, shapes_name: str|None=None, cell_id_col: str|None=None, gene_col: str|None='feature_name', seg_method: str|None=None, use_original_cell_ids: bool=False):
+    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, image_name: str='morphology', points_name: str|None=None, shapes_name: str|None=None, cell_id_col: str|None=None, gene_col: str|None='feature_name', seg_method: str|None=None, use_original_cell_ids: bool=False):
         """Take a xenium spatialdata file or object and load its data into a SegmentedSpotTable
         The spatialdata object should follow the Xenium convention as defined in spatialdata-io.xenium()
 
@@ -3496,6 +3550,9 @@ class SegmentedSpotTable:
         z_depth : float, optional
             The z depth to use when binning continuous z locations into integer z planes.
             Make sure to set this to 1.0 if your xenium data has already been binned to z planes.
+        xenium_min_qv : float or None, optional
+            The minimum quality value (Q-Score) for transcripts stored in this SpatialData object. 
+            If None, tries to pull from points table. If 'qv' column doesn't exist, will default to np.nan
         image_name : str, optional
             The name of the image to load from the spatial data. Or if morphology_path is provided, the name to assign to the morphology image.
         points_name : str, optional
@@ -3539,7 +3596,7 @@ class SegmentedSpotTable:
                 warnings.warn('Points name was left unspecified and there are multiple Points elements. Loading to the first listed by default')
             points_name = list(sd_object.points.keys())[0]
 
-        raw_spot_table = SpotTable.load_xenium_spatialdata(sd_object=sd_object, morphology_path=morphology_path, z_depth=z_depth, image_name=image_name, points_name=points_name, gene_col=gene_col)
+        raw_spot_table = SpotTable.load_xenium_spatialdata(sd_object=sd_object, morphology_path=morphology_path, z_depth=z_depth, min_qv=min_qv, image_name=image_name, points_name=points_name, gene_col=gene_col)
         
         return cls._load_spatialdata_cids_polygons(raw_spot_table, sd_object, points_name, shapes_name, cell_id_col, seg_method, use_original_cell_ids, set(['UNASSIGNED']))
     

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1562,7 +1562,7 @@ class SpotTable:
         # 'global_x', 'global_y', and 'global_z' are already renamed to 'x', 'y', and 'z' by spatialdata_io's merscope() function
         pos = sd_object[points_name][['x', 'y', 'z']].to_dask_array().compute()
         
-        max_gene_len = max(map(len, sd_object[list(sd_object.points.keys())[0]]['gene']))
+        max_gene_len = max(map(len, sd_object[list(sd_object.points.keys())[0]]['gene'].compute()))
         with warnings.catch_warnings(): # Dask array throws an error about converting from dataframe
             warnings.simplefilter("ignore")
             gene_names = sd_object[list(sd_object.points.keys())[0]]['gene'].to_dask_array().compute().astype(f'U{max_gene_len}')
@@ -1656,7 +1656,7 @@ class SpotTable:
         z_bins = np.arange(0, np.max(pos[:, 2]) + z_depth, z_depth) 
         pos[:, 2] = (np.digitize(pos[:,2], z_bins) - 1).astype(int)
         
-        max_gene_len = max(map(len, sd_object[list(sd_object.points.keys())[0]][gene_col]))
+        max_gene_len = max(map(len, sd_object[list(sd_object.points.keys())[0]][gene_col].compute()))
         with warnings.catch_warnings(): # Dask array throws an error about converting from dataframe
             warnings.simplefilter("ignore")
             gene_names = sd_object[list(sd_object.points.keys())[0]][gene_col].to_dask_array().compute().astype(f'U{max_gene_len}')

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -1570,55 +1570,16 @@ class SpotTable:
         return cls(pos=pos, gene_names=gene_names, images=images)
 
     @classmethod
-    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
-        """Take a xenium spatialdata file or object and load its data into a SpotTable
-        The spatialdata object should follow the xenium convention as defined in spatialdata-io.xenium()
-        
-        Parameters
-        ----------
-        sd_file : str or Path, optional
-            The path to the spatial data file. If provided, `sd_object` should be None.
-        sd_object : spatialdata.SpatialData, optional
-            An instance of the SpatialData object. If provided, `sd_file` should be None.
-        morphology_path : str or Path, optional
-            spatialdata_io.xenium only loads the focus and mip images. Since SIS relies on the original morphology file,
-            we provide the ability to load the morphology file via the path.
-            If provided, it will be added to the spatialdata object under the name given by [image_name].
-        z_depth : float, optional
-            The z depth to use when binning continuous z locations into integer z planes.
-            Make sure to set this to 1.0 if your xenium data has already been binned to z planes.
-        min_qv : float or None, optional
-            The minimum quality value (Q-Score) for transcripts stored in this SpatialData object. 
-            If None, tries to pull from points table. If 'qv' column doesn't exist, will default to np.nan
-        image_name : str, optional
-            The name of the image to load from the spatial data. Or if morphology_path is provided, the name to assign to the morphology image.
-        points_name : str, optional
-            The name of the points to load from the spatial data. If None and multiple points are available, the first one will be used.
-        gene_col : str, optional
-            The name of the column in the points table that contains the gene names.
-
-        Raises
-        ------
-        ValueError
-            If both `sd_file` and `sd_object` are None or if both are provided
-            or if the transformation applied to the image is not supported (i.e. rotation or shear).
-
-        Returns
-        -------
-        SpotTable
-            A SpotTable containing the transcripts and images loaded from the spatial data object/file system
+    def _load_xenium_spatialdata_internal(cls, sd_object: spatialdata.SpatialData, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
+        """Contains all the logic for load_xenium_spatialdata but returns a min_qv mask.
+        This reduces duplicate code while allowing _load_spatialdata_cids_polygons to access the min_qv mask
+        See load_xenium_spatialdata docstring for explanation of function
         """
         import warnings
-        import spatialdata as sd # Import in function so we don't throw error if spatialdata is not installed and this function is not used
         from spatialdata.transformations import get_transformation, Identity
         from .image import SpatialDataImage, ImageTransform
         from .spatialdata import _is_supported_transformation
         
-        if (sd_file is None) == (sd_object is None):
-            raise ValueError('One and exactly one of sd_file and sd_object should be defined')
-        if sd_file is not None:
-            sd_object = sd.read_zarr(sd_file)
-
         if points_name is None:
             if len(sd_object.points.keys()) > 1:
                 warnings.warn('Points name was left unspecified and there are multiple Points elements. Loading to the first listed by default')
@@ -1649,26 +1610,92 @@ class SpotTable:
                                 image_name)
         
         # Read in the transcripts
+        # read in the minimum QV if it exists, otherwise set to np.nan
+        if min_qv is None:
+            if 'qv' in sd_object[list(sd_object.points.keys())[0]].columns:
+                min_qv = sd_object[list(sd_object.points.keys())[0]]['qv'].min().compute()
+                mask = (sd_object[list(sd_object.points.keys())[0]]['qv'] >= min_qv).compute().to_numpy()
+            else:
+                min_qv = 0
+                mask = np.ones(len(sd_object[list(sd_object.points.keys())[0]]), dtype=bool)
+        else:
+            if 'qv' in sd_object[list(sd_object.points.keys())[0]].columns:
+                mask = (sd_object[list(sd_object.points.keys())[0]]['qv'] >= min_qv).compute().to_numpy()
+            else:
+                if not force_qv_store:
+                    warnings.warn('min_qv was specified but no "qv" column found in points table. Setting min_qv to 0 & keeping all values. If you still want to store the min_qv value, set force_qv_store=True')
+                    min_qv = 0
+                else:
+                    warnings.warn(f'min_qv was specified but no "qv" column found in points table. force_qv_store was set to True, so storing xenium_min_qv={min_qv} but keeping all transcripts')
+                mask = np.ones(len(sd_object[list(sd_object.points.keys())[0]]), dtype=bool)
+                
         # 'x_location', 'y_location', and 'z_location' are already renamed to 'x', 'y', and 'z' by spatialdata_io's xenium() funcytion
-        pos = sd_object[list(sd_object.points.keys())[0]][['x', 'y', 'z']].to_dask_array().compute()
+        pos = sd_object[list(sd_object.points.keys())[0]][['x', 'y', 'z']].to_dask_array().compute()[mask]
         
         # Xenium z-values are continuous. For image operations, we bin float z locations to integers
         z_bins = np.arange(0, np.max(pos[:, 2]) + z_depth, z_depth) 
         pos[:, 2] = (np.digitize(pos[:,2], z_bins) - 1).astype(int)
         
-        max_gene_len = max(map(len, sd_object[list(sd_object.points.keys())[0]][gene_col].compute()))
+        max_gene_len = max(map(len, sd_object[list(sd_object.points.keys())[0]][gene_col].compute()[mask]))
         with warnings.catch_warnings(): # Dask array throws an error about converting from dataframe
             warnings.simplefilter("ignore")
-            gene_names = sd_object[list(sd_object.points.keys())[0]][gene_col].to_dask_array().compute().astype(f'U{max_gene_len}')
+            gene_names = sd_object[list(sd_object.points.keys())[0]][gene_col].to_dask_array().compute()[mask].astype(f'U{max_gene_len}')
 
-        # read in the minimum QV if it exists, otherwise set to np.nan
-        if min_qv is None:
-            if 'qv' in sd_object[list(sd_object.points.keys())[0]].columns:
-                min_qv = sd_object[list(sd_object.points.keys())[0]]['qv'].min().compute()
-            else:
-                min_qv = np.nan
+        return cls(pos=pos, gene_names=gene_names, images=image, xenium_min_qv=min_qv), mask
 
-        return cls(pos=pos, gene_names=gene_names, images=image, xenium_min_qv=min_qv)
+    @classmethod
+    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, gene_col: str='feature_name'):
+        """Take a xenium spatialdata file or object and load its data into a SpotTable
+        The spatialdata object should follow the xenium convention as defined in spatialdata-io.xenium()
+        
+        Parameters
+        ----------
+        sd_file : str or Path, optional
+            The path to the spatial data file. If provided, `sd_object` should be None.
+        sd_object : spatialdata.SpatialData, optional
+            An instance of the SpatialData object. If provided, `sd_file` should be None.
+        morphology_path : str or Path, optional
+            spatialdata_io.xenium only loads the focus and mip images. Since SIS relies on the original morphology file,
+            we provide the ability to load the morphology file via the path.
+            If provided, it will be added to the spatialdata object under the name given by [image_name].
+        z_depth : float, optional
+            The z depth to use when binning continuous z locations into integer z planes.
+            Make sure to set this to 1.0 if your xenium data has already been binned to z planes.
+        min_qv : float or None, optional
+            The minimum quality value (Q-Score) for transcripts stored in this SpatialData object. 
+            If None, tries to pull from points table. If 'qv' column doesn't exist, will default to np.nan
+        force_qv_log : bool, optional
+            If the qv column cannot be found in the points data & min_qv was set load_xenium_spatialdata defaults to loading all transcripts & storing min_qv as 0.
+            Set force_qv_store=True if you want to override this behavior and store min_qv as set.
+            e.g. If you know what the qv filter was on the original data and want to store it.
+        image_name : str, optional
+            The name of the image to load from the spatial data. Or if morphology_path is provided, the name to assign to the morphology image.
+        points_name : str, optional
+            The name of the points to load from the spatial data. If None and multiple points are available, the first one will be used.
+        gene_col : str, optional
+            The name of the column in the points table that contains the gene names.
+
+        Raises
+        ------
+        ValueError
+            If both `sd_file` and `sd_object` are None or if both are provided
+            or if the transformation applied to the image is not supported (i.e. rotation or shear).
+
+        Returns
+        -------
+        SpotTable
+            A SpotTable containing the transcripts and images loaded from the spatial data object/file system
+        """
+        import spatialdata as sd # Import in function so we don't throw error if spatialdata is not installed and this function is not used
+
+        if (sd_file is None) == (sd_object is None):
+            raise ValueError('One and exactly one of sd_file and sd_object should be defined')
+        if sd_file is not None:
+            sd_object = sd.read_zarr(sd_file)
+
+        spot_table, _ = cls._load_xenium_spatialdata_internal(sd_object, morphology_path, z_depth, min_qv, force_qv_store, image_name, points_name, gene_col)
+
+        return spot_table
 
 
 class SegmentedSpotTable:
@@ -3533,7 +3560,7 @@ class SegmentedSpotTable:
         return cls._load_spatialdata_cids_polygons(raw_spot_table, sd_object, points_name, shapes_name, cell_id_col, seg_method, use_original_cell_ids, set(['-1']))
     
     @classmethod
-    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, image_name: str='morphology', points_name: str|None=None, shapes_name: str|None=None, cell_id_col: str|None=None, gene_col: str|None='feature_name', seg_method: str|None=None, use_original_cell_ids: bool=False):
+    def load_xenium_spatialdata(cls, sd_file: str|Path|None=None, sd_object: spatialdata.SpatialData|None=None, morphology_path: str|Path|None=None, z_depth: float=3.0, min_qv: float|None=None, force_qv_store: bool=False, image_name: str='morphology', points_name: str|None=None, shapes_name: str|None=None, cell_id_col: str|None=None, gene_col: str|None='feature_name', seg_method: str|None=None, use_original_cell_ids: bool=False):
         """Take a xenium spatialdata file or object and load its data into a SegmentedSpotTable
         The spatialdata object should follow the Xenium convention as defined in spatialdata-io.xenium()
 
@@ -3550,9 +3577,13 @@ class SegmentedSpotTable:
         z_depth : float, optional
             The z depth to use when binning continuous z locations into integer z planes.
             Make sure to set this to 1.0 if your xenium data has already been binned to z planes.
-        xenium_min_qv : float or None, optional
+        min_qv : float or None, optional
             The minimum quality value (Q-Score) for transcripts stored in this SpatialData object. 
             If None, tries to pull from points table. If 'qv' column doesn't exist, will default to np.nan
+        force_qv_log : bool, optional
+            If the qv column cannot be found in the points data & min_qv was set load_xenium_spatialdata defaults to loading all transcripts & storing min_qv as 0.
+            Set force_qv_store=True if you want to override this behavior and store min_qv as set.
+            e.g. If you know what the qv filter was on the original data and want to store it.
         image_name : str, optional
             The name of the image to load from the spatial data. Or if morphology_path is provided, the name to assign to the morphology image.
         points_name : str, optional
@@ -3596,12 +3627,12 @@ class SegmentedSpotTable:
                 warnings.warn('Points name was left unspecified and there are multiple Points elements. Loading to the first listed by default')
             points_name = list(sd_object.points.keys())[0]
 
-        raw_spot_table = SpotTable.load_xenium_spatialdata(sd_object=sd_object, morphology_path=morphology_path, z_depth=z_depth, min_qv=min_qv, image_name=image_name, points_name=points_name, gene_col=gene_col)
+        raw_spot_table, qv_mask = SpotTable._load_xenium_spatialdata_internal(sd_object, morphology_path, z_depth, min_qv, force_qv_store, image_name, points_name, gene_col)
         
-        return cls._load_spatialdata_cids_polygons(raw_spot_table, sd_object, points_name, shapes_name, cell_id_col, seg_method, use_original_cell_ids, set(['UNASSIGNED']))
+        return cls._load_spatialdata_cids_polygons(raw_spot_table, sd_object, points_name, qv_mask, shapes_name, cell_id_col, seg_method, use_original_cell_ids, set(['UNASSIGNED']))
     
     @classmethod
-    def _load_spatialdata_cids_polygons(cls, raw_spot_table, sd_object, points_name, shapes_name, cell_id_col, seg_method, use_original_cell_ids, bg_ids):
+    def _load_spatialdata_cids_polygons(cls, raw_spot_table, sd_object, points_name, qv_mask, shapes_name, cell_id_col, seg_method, use_original_cell_ids, bg_ids):
         """Helper function for loading spatial data cell IDs and polygons from a given spatial data object into a SegmentedSpotTable
         Called by load_merscope_spatialdata and load_xenium_spatialdata
 
@@ -3615,6 +3646,10 @@ class SegmentedSpotTable:
             The spatial data object containing points and shapes.
         points_name : str
             The name of the points in the spatial data object.
+        qv_mask : np.ndarray or None
+            Mask for which cell_ids to keep in order to match transcript count.
+            Used when loading xenium data with a quality value (Q-Score) filter for transcripts. 
+            If None, does not filter
         shapes_name : str, optional
             The name of the shapes in the spatial data object. If None and multiple shapes exist, the first shape will be used.
         cell_id_col : str, optional
@@ -3647,6 +3682,8 @@ class SegmentedSpotTable:
             cell_id_col = 'cell_id' if 'cell_id' in sd_object[points_name].columns else 'cell_ids'
         
         cell_ids = sd_object[points_name][cell_id_col].compute().values
+        if qv_mask is not None:
+            cell_ids = cell_ids[qv_mask]
         if use_original_cell_ids: 
             # Must ensure that cell_ids can be ints
             try: 
@@ -3658,7 +3695,7 @@ class SegmentedSpotTable:
             # If we aren't using the original cell ids, we will still put them into cell_labels to preserve them
             # We also generate new cell ids between [1, num_cells]
             cell_ids, cell_labels = cls._default_cell_ids(cell_ids, bg_ids=bg_ids)
-
+        
         # Allow the user to specify a segmentation method
         spot_table = cls(spot_table=raw_spot_table, cell_ids=cell_ids, seg_metadata={'seg_method': seg_method} if seg_method is not None else None)
         spot_table.cell_labels = cell_labels

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -3112,7 +3112,7 @@ class SegmentedSpotTable:
                 pos=fields['pos'],
                 gene_ids=fields['gene_ids'],
                 gene_id_to_name=fields['gene_id_to_name'],
-                images=images
+                images=images,
                 xenium_min_qv=fields['xenium_min_qv'] if fields['xenium_min_qv'] != "None" else None
                 )
         

--- a/sis/spot_table.py
+++ b/sis/spot_table.py
@@ -951,7 +951,7 @@ class SpotTable:
         pos = fields['pos']
         gene_ids = fields['gene_ids'] 
         gene_id_to_name = fields['gene_id_to_name']
-        xenium_min_qv = fields['xenium_min_qv'] if fields['xenium_min_qv'] != "None" else None
+        xenium_min_qv = fields['xenium_min_qv'].item() if fields['xenium_min_qv'].item() != "None" else None
         return cls(pos=pos, gene_ids=gene_ids, gene_id_to_name=gene_id_to_name, images=images, xenium_min_qv=xenium_min_qv)
 
     def _make_gene_index(cls, gene_names):
@@ -3113,7 +3113,7 @@ class SegmentedSpotTable:
                 gene_ids=fields['gene_ids'],
                 gene_id_to_name=fields['gene_id_to_name'],
                 images=images,
-                xenium_min_qv=fields['xenium_min_qv'] if fields['xenium_min_qv'] != "None" else None
+                xenium_min_qv=fields['xenium_min_qv'].item() if fields['xenium_min_qv'].item() != "None" else None
                 )
         
         # handle underscores and object arrays


### PR DESCRIPTION
Cell by genes created with `SegmentedSpotTable.save_xenium_kit_cbg()` now include cells with zero transcripts. Because `SegmentedSpotTable` only stores information about transcripts (and segmentations relative to those transcripts), these cells are added to the cell by gene after it's creation. Their information is copied over from xenium's `cells.parquet` output file. Some columns in the `anndata.obs` are derived from the spots themselves and thus their values are left as `None` for the transcriptless cells.

I would encourage the reviewers to test run `SegmentedSpotTable.save_xenium_kit_cbg()` on a piece of their data and ensure that it is as expected.